### PR TITLE
fix missing include

### DIFF
--- a/mwdust/util/SFD_CodeC/subs_fits.c
+++ b/mwdust/util/SFD_CodeC/subs_fits.c
@@ -14,6 +14,7 @@
 /******************************************************************************/
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 #include <ctype.h> /* For function toupper() */


### PR DESCRIPTION
Installing `mwdust` fails consistently on Mac OS X 10.15 (feel free to ask for more system information, if necessary)

`clang` details
```
$ clang -v
Apple clang version 12.0.0 (clang-1200.0.32.27)
Target: x86_64-apple-darwin19.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```


The failure happens during the building of the c extensions, which can be replicated with 

```
$ sudo python setup.py build_ext
```

producing the following error

```
<snip>
  mwdust/util/SFD_CodeC/subs_fits.c:1869:14: error: implicitly declaring library function 'abs' with type 'int (int)' [-Werror,-Wimplicit-function-declaration]
        *pTime=abs(timeHour) + timeMin/60.0 + timeSec/3600.0;
               ^
  mwdust/util/SFD_CodeC/subs_fits.c:1869:14: note: include the header <stdlib.h> or explicitly provide a declaration for 'abs'
</snip>
```

after adding the appropriate import to `subs_fits.c`, the installation succeeds. 
