### PR TITLE
Better Windows support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         pip install pyparsing==2.4.7 # For issue with six which requires pyparsing < 3
     - name: Test downloads
       env:
-        DUST_DIR: ${{ GITHUB_WORKSPACE }}/data/
+        DUST_DIR: $env:GITHUB_WORKSPACE/data/
       run: |
         python setup.py install --test-downloads --all-downloads
     - name: Install package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest,macos-latest,windows-latest]
         python-version: [3.9,"3.10"]
@@ -22,9 +23,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
         pip install numpy==${{ matrix.numpy-version }}
         pip install pyparsing==2.4.7 # For issue with six which requires pyparsing < 3
+        pip install cython # for compiliong h5py from source
     - name: Test downloads
       env:
         DUST_DIR: ${{github.workspace}}/data/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install numpy==${{ matrix.numpy-version }}
         pip install pyparsing==2.4.7 # For issue with six which requires pyparsing < 3
+    - name: Test downloads
+      run: |
+        python setup.py install --test-downloads --all-downloads
     - name: Install package
       run: |
         python setup.py install --no-downloads

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest,macos-latest,windows-latest]
-        python-version: [3.9,"3.10"]
+        python-version: [3.9]
         numpy-version: ["1.20","1.21","1.22"]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         pip install pyparsing==2.4.7 # For issue with six which requires pyparsing < 3
     - name: Test downloads
       env:
-        DUST_DIR: data/
+        DUST_DIR: {{ GITHUB_WORKSPACE }}/data/
       run: |
         python setup.py install --test-downloads --all-downloads
     - name: Install package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,20 @@ jobs:
         python -m pip install --upgrade pip wheel
         pip install numpy==${{ matrix.numpy-version }}
         pip install pyparsing==2.4.7 # For issue with six which requires pyparsing < 3
-        pip install cython # for compiliong h5py from source
+    - name: Create data directory
+      if: runner.os == 'Windows'
+      env:
+        DUST_DIR: ${{github.workspace}}/data/
+      run: New-Item -ItemType directory -Path $env:DUST_DIR
+    - name: Create data directory
+      if: runner.os != 'Windows'
+      env:
+        DUST_DIR: ${{github.workspace}}/data/
+      run: mkdir $DUST_DIR  
     - name: Test downloads
       env:
         DUST_DIR: ${{github.workspace}}/data/
       run: |
-        mkdir $DUST_DIR
         python setup.py install --test-downloads --all-downloads
     - name: Install package
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.9]
-        numpy-version: ["1.20","1.21"]
+        os: [ubuntu-latest,macos-latest,windows-latest]
+        python-version: [3.9,"3.10"]
+        numpy-version: ["1.20","1.21","1.22"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
       env:
         DUST_DIR: ${{github.workspace}}/data/
       run: |
+        mkdir $DUST_DIR
         python setup.py install --test-downloads --all-downloads
     - name: Install package
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         pip install pyparsing==2.4.7 # For issue with six which requires pyparsing < 3
     - name: Test downloads
       env:
-        DUST_DIR: $env:GITHUB_WORKSPACE/data/
+        DUST_DIR: ${{github.workspace}}/data/
       run: |
         python setup.py install --test-downloads --all-downloads
     - name: Install package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         pip install pyparsing==2.4.7 # For issue with six which requires pyparsing < 3
     - name: Test downloads
       env:
-        DUST_DIR: {{ GITHUB_WORKSPACE }}/data/
+        DUST_DIR: ${{ GITHUB_WORKSPACE }}/data/
       run: |
         python setup.py install --test-downloads --all-downloads
     - name: Install package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
         pip install numpy==${{ matrix.numpy-version }}
         pip install pyparsing==2.4.7 # For issue with six which requires pyparsing < 3
     - name: Test downloads
+      env:
+        DUST_DIR: data/
       run: |
         python setup.py install --test-downloads --all-downloads
     - name: Install package

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,15 @@ installing with sudo and you might have to use the ``-E`` option when
 you are installing with sudo to transfer your environment variables to
 sudo.
 
+Note that this code currently does not really work on Windows. The 
+installation command should download and otherwise work as long as 
+you have the ``gzip`` utility (e.g., through install ``7zip``), 
+but the SFD code will not be compiled (so the ``SFD`` map will not 
+be available) and because ``healpy`` is unavailable on Windows, all 
+HEALPIx-based maps (e.g., `CombinedXX`, `GreenXX`) will also not 
+work. Thus, the code is only marginally useful on Windows. Install 
+on Linux/Mac OS for full features.
+
 Dust Data
 ---------
 

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,9 @@ default, only the most commonly-used dust maps are downloaded; to
 download all maps, use the ``--all-downloads`` installation option
 (you can just re-run the installation with this option to add this
 later).  The installation option ``--no-downloads`` turns all
-downloads off.
+downloads off. By default, downloads are run without showing any 
+progress, but if you want to see the downloads's progression, use 
+``--verbose-downloads``.
 
 The data are put in subdirectories of a directory ``DUST_DIR``, with
 roughly the following lay-out::

--- a/mwdust/util/read_SFD.py
+++ b/mwdust/util/read_SFD.py
@@ -5,6 +5,8 @@ import ctypes.util
 from numpy.ctypeslib import ndpointer
 import os, os.path
 import numpy
+import platform
+WIN32= platform.system() == 'Windows'
 #Find and load the library
 _lib = None
 _libname = ctypes.util.find_library('sfd_c')
@@ -23,7 +25,7 @@ if _lib is None:
             _lib = None
         else:
             break
-if _lib is None:
+if _lib is None and not WIN32:
     raise IOError('SFD/C module not found')
 
 #MAP path names

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ def download_file(url,output,desc,notest=False):
             cmd.append('--silent')
         if _TEST_DOWNLOADS:
             if notest: return None
-            cmd.extend(['--output','/dev/null','--head'])
+            cmd.extend(['--output','-','--head'])
         else:
             cmd.extend(['-o',output])
         subprocess.check_call(cmd)

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ from distutils.core import Extension
 import sys
 import subprocess
 import glob
+import platform
+WIN32= platform.system() == 'Windows'
 
 long_description= ''
 previous_line= ''
@@ -74,7 +76,7 @@ if _DOWNLOAD_SFD and sys.argv[1] in ('install','develop'):
                 print('\033[1m'+"Problem changing ownership of data directory ..."+'\033[0m')
             print('\033[1m'+'Downloading SFD dust maps ...'+'\033[0m')
             try:
-                subprocess.check_call(['wget',_SFD_URL_NGP,'-O',
+                subprocess.check_call(['curl','-sfL',_SFD_URL_NGP,'-o',
                                        os.path.join(os.getenv('DUST_DIR'),'maps',
                                                     'SFD_dust_4096_ngp.fits')])
             except subprocess.CalledProcessError:
@@ -89,7 +91,7 @@ if _DOWNLOAD_SFD and sys.argv[1] in ('install','develop'):
         if not os.path.exists(os.path.join(os.getenv('DUST_DIR'),'maps',
                                            'SFD_dust_4096_sgp.fits')):
             try:
-                subprocess.check_call(['wget',_SFD_URL_SGP,'-O',
+                subprocess.check_call(['curl','-sfL',_SFD_URL_SGP,'-o',
                                        os.path.join(os.getenv('DUST_DIR'),'maps',
                                                     'SFD_dust_4096_sgp.fits')])
             except subprocess.CalledProcessError:
@@ -109,8 +111,8 @@ if _DOWNLOAD_DRIMMEL \
     if not os.path.exists('mwdust/util/drimmeldata/data-for.tar.gz'):
         print('\033[1m'+'Downloading Drimmel et al. (2003) dust maps ...'+'\033[0m')
         try:
-            subprocess.check_call(['wget','%s' % _DRIMMEL_URL,
-                                   '-O','mwdust/util/drimmeldata/data-for.tar.gz'])
+            subprocess.check_call(['curl','-sfL','%s' % _DRIMMEL_URL,
+                                   '-o','mwdust/util/drimmeldata/data-for.tar.gz'])
         except subprocess.CalledProcessError:
             print("Downloading Drimmel dust-map data from %s failed ..." % _DRIMMEL_URL)
         try:
@@ -139,20 +141,21 @@ if _DOWNLOAD_MARSHALL and sys.argv[1] in ('install','develop'):
                                                 'table1.dat')):
             print('\033[1m'+'Downloading Marshall et al. (2006) dust maps ...'+'\033[0m')
             try:
-                subprocess.check_call(['wget',
+                subprocess.check_call(['curl','-sfL',
                                        '%s/table1.dat.gz' % _MARSHALL_URL,
-                                       '-O',
+                                       '-o',
                                        os.path.join(os.getenv('DUST_DIR'),
                                                     'marshall06',
                                                     'table1.dat.gz')])
             except subprocess.CalledProcessError:
                 print('\033[1m'+"Downloading Marshall dust-map data from %s/table1.dat.gz failed ..." % _MARSHALL_URL +'\033[0m')
             try:
-                subprocess.check_call(['gunzip',
+                subprocess.check_call(['gzip','-d',
                                        os.path.join(os.getenv('DUST_DIR'),
                                                     'marshall06',
-                                                    'table1.dat.gz')])
-            except subprocess.CalledProcessError:
+                                                    'table1.dat.gz')],
+                                      shell=WIN32)
+            except (subprocess.CalledProcessError,FileNotFoundError):
                 print('\033[1m'+"Gunzipping Marshall et al. dust-map data failed ..."+'\033[0m')
             try:
                 subprocess.check_call(['chown',os.getenv('SUDO_USER'),
@@ -163,8 +166,8 @@ if _DOWNLOAD_MARSHALL and sys.argv[1] in ('install','develop'):
                 print('\033[1m'+"Problem changing ownership of data file..."+'\033[0m')
             #Also download the ReadMe file
             try:
-                subprocess.check_call(['wget','%s/ReadMe' % _MARSHALL_URL,
-                                       '-O',
+                subprocess.check_call(['curl','-sfL','%s/ReadMe' % _MARSHALL_URL,
+                                       '-o',
                                        os.path.join(os.getenv('DUST_DIR'),
                                                     'marshall06',
                                                     'ReadMe')])
@@ -204,9 +207,9 @@ if _DOWNLOAD_SALE and sys.argv[1] in ('install','develop'):
             print('\033[1m'+'Downloading Sale et al. (2014) dust maps ...'+'\033[0m')
             if _SALE_CDS:
                 try:
-                    subprocess.check_call(['wget',
+                    subprocess.check_call(['curl','-sfL',
                                            '%s/table1.dat.gz' % _SALE_URL,
-                                           '-O',
+                                           '-o',
                                            os.path.join(os.getenv('DUST_DIR'),
                                                         'sale14',
                                                         'table1.dat.gz')])
@@ -228,8 +231,8 @@ if _DOWNLOAD_SALE and sys.argv[1] in ('install','develop'):
                     print('\033[1m'+"Problem changing ownership of data file..."+'\033[0m')
                 #Also download the ReadMe file
                 try:
-                    subprocess.check_call(['wget','%s/ReadMe' % _SALE_URL,
-                                           '-O',
+                    subprocess.check_call(['curl','-sfL','%s/ReadMe' % _SALE_URL,
+                                           '-o',
                                            os.path.join(os.getenv('DUST_DIR'),
                                                         'sale14',
                                                         'ReadMe')])
@@ -244,9 +247,9 @@ if _DOWNLOAD_SALE and sys.argv[1] in ('install','develop'):
                     print('\033[1m'+"Problem changing ownership of data file..."+'\033[0m')
             else:
                 try:
-                    subprocess.check_call(['wget',
+                    subprocess.check_call(['curl','-sfL',
                                            _SALE_URL,
-                                           '-O',
+                                           '-o',
                                            os.path.join(os.getenv('DUST_DIR'),
                                                         'sale14',
                                                         'Amap.tar.gz')])
@@ -304,9 +307,9 @@ if _DOWNLOAD_GREEN and sys.argv[1] in ('install','develop'):
                                            'dust-map-3d.h5')):
             print('\033[1m'+'Downloading Green et al. (2015) dust maps ...'+'\033[0m')
             try:
-                subprocess.check_call(['wget',
+                subprocess.check_call(['curl','-sfL',
                                        _GREEN_URL,
-                                       '-O',
+                                       '-o',
                                        os.path.join(os.getenv('DUST_DIR'),
                                                     'green15',
                                                     'dust-map-3d.h5')])
@@ -339,9 +342,9 @@ if _DOWNLOAD_GREEN17 and sys.argv[1] in ('install','develop'):
                                            'bayestar2017.h5')):
             print('\033[1m'+'Downloading Green et al. (2018) dust maps ...'+'\033[0m')
             try:
-                subprocess.check_call(['wget',
+                subprocess.check_call(['curl','-sfL',
                                        _GREEN_URL,
-                                       '-O',
+                                       '-o',
                                        os.path.join(os.getenv('DUST_DIR'),
                                                     'green17',
                                                     'bayestar2017.h5')])
@@ -374,9 +377,9 @@ if _DOWNLOAD_GREEN19 and sys.argv[1] in ('install','develop'):
                                            'bayestar2019.h5')):
             print('\033[1m'+'Downloading Green et al. (2019) dust maps ...'+'\033[0m')
             try:
-                subprocess.check_call(['wget',
+                subprocess.check_call(['curl','-sfL',
                                        _GREEN_URL,
-                                       '-O',
+                                       '-o',
                                        os.path.join(os.getenv('DUST_DIR'),
                                                     'green19',
                                                     'bayestar2019.h5')])
@@ -410,9 +413,9 @@ if _DOWNLOAD_COMBINED19 and sys.argv[1] in ('install','develop'):
                                            'combine19.h5')):
             print('\033[1m'+'Downloading combined dust map (2019) ...'+'\033[0m')
             try:
-                subprocess.check_call(['wget',
+                subprocess.check_call(['curl','-sfL',
                                        _COMBINED_URL,
-                                       '-O',
+                                       '-o',
                                        os.path.join(os.getenv('DUST_DIR'),
                                                     'combined19',
                                                     'combine19.h5')])
@@ -447,9 +450,9 @@ if _DOWNLOAD_COMBINED and sys.argv[1] in ('install','develop'):
                                            'dust-map-3d.h5')):
             print('\033[1m'+'Downloading combined dust map (2015) ...'+'\033[0m')
             try:
-                subprocess.check_call(['wget',
+                subprocess.check_call(['curl','-sfL',
                                        _COMBINED_URL,
-                                       '-O',
+                                       '-o',
                                        os.path.join(os.getenv('DUST_DIR'),
                                                     'combined15',
                                                     'dust-map-3d.h5')])
@@ -473,7 +476,10 @@ sfd_c= Extension('sfd_c',
                  extra_compile_args=['-DLITTLE_ENDIAN'],
                  include_dirs=['mwdust/util/SFD_CodeC'])
 
-ext_modules=[sfd_c]
+if not WIN32:
+    ext_modules=[sfd_c]
+else:
+    ext_modules= None
 
 setup(name='mwdust',
       version='1.2.dev',
@@ -490,7 +496,7 @@ setup(name='mwdust',
                                    'extCurves/apj398709t6_ascii.txt',
                                    'drimmeldata/*.dat']},
       install_requires=['numpy','scipy','matplotlib','asciitable',
-                        'h5py','healpy'],
+                        'h5py'],#,'healpy'],
       ext_modules=ext_modules,
       classifiers=[
         "Development Status :: 6 - Mature",

--- a/setup.py
+++ b/setup.py
@@ -423,6 +423,11 @@ if not WIN32:
 else:
     ext_modules= None
 
+install_requires= ['numpy','scipy','matplotlib','asciitable',
+                   'h5py']
+if not WIN32:
+    install_requires.append('healpy')
+
 setup(name='mwdust',
       version='1.2.dev',
       description='Dust in the Milky Way',
@@ -437,8 +442,7 @@ setup(name='mwdust',
       package_data={'mwdust/util':['extCurves/extinction.tbl',
                                    'extCurves/apj398709t6_ascii.txt',
                                    'drimmeldata/*.dat']},
-      install_requires=['numpy','scipy','matplotlib','asciitable',
-                        'h5py'],#,'healpy'],
+      install_requires=install_requires,
       ext_modules=ext_modules,
       classifiers=[
         "Development Status :: 6 - Mature",

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,49 @@ else:
     _DOWNLOAD_GREEN19= False
     _DOWNLOAD_COMBINED= False
     _DOWNLOAD_COMBINED19= False
+    
+try:
+    test_downloads_pos= sys.argv.index('--test-downloads')
+except ValueError:
+    _TEST_DOWNLOADS= False
+else:
+    del sys.argv[test_downloads_pos]
+    _TEST_DOWNLOADS= True    
+
+try:
+    verbose_downloads_pos= sys.argv.index('--verbose-downloads')
+except ValueError:
+    _VERBOSE_DOWNLOADS= False
+else:
+    del sys.argv[test_downloads_pos]
+    _VERBOSE_DOWNLOADS= True    
+
+def download_file(url,output,desc,notest=False):
+    print('\033[1m'+'Downloading {} dust maps ...'.format(desc)+'\033[0m')
+    try:
+        cmd= ['curl','-fL',url]
+        if not _VERBOSE_DOWNLOADS:
+            cmd.append('--silent')
+        if _TEST_DOWNLOADS:
+            if notest: return None
+            cmd.extend(['--output','/dev/null','--head'])
+        else:
+            cmd.extend(['-o',output])
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError:
+        print('\033[1m'+"Downloading {} dust-map data from {} failed ...".format(desc,url)+'\033[0m')
+        if _TEST_DOWNLOADS:
+            raise
+    return None
+        
+def chown_file(output):
+    if not _TEST_DOWNLOADS:
+        try:
+            subprocess.check_call(['chown',os.getenv('SUDO_USER'),
+                                   output])
+        except (subprocess.CalledProcessError,TypeError):
+            print('\033[1m'+"Problem changing ownership of data file..."+'\033[0m')
+    return None
 
 #Download SFD maps
 _SFD_URL_NGP= 'https://svn.sdss.org/public/data/sdss/catalogs/dust/trunk/maps/SFD_dust_4096_ngp.fits'
@@ -74,53 +117,37 @@ if _DOWNLOAD_SFD and sys.argv[1] in ('install','develop'):
                                                     'maps')])
             except (subprocess.CalledProcessError,TypeError):
                 print('\033[1m'+"Problem changing ownership of data directory ..."+'\033[0m')
-            print('\033[1m'+'Downloading SFD dust maps ...'+'\033[0m')
-            try:
-                subprocess.check_call(['curl','-sfL',_SFD_URL_NGP,'-o',
-                                       os.path.join(os.getenv('DUST_DIR'),'maps',
-                                                    'SFD_dust_4096_ngp.fits')])
-            except subprocess.CalledProcessError:
-                print('\033[1m'+"Downloading SFD dust-map data from %s failed ..." % _SFD_URL_NGP +'\033[0m')
-            try:
-                subprocess.check_call(['chown',os.getenv('SUDO_USER'),
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'maps',
-                                                    'SFD_dust_4096_ngp.fits')])
-            except (subprocess.CalledProcessError,TypeError):
-                print('\033[1m'+"Problem changing ownership of data file..."+'\033[0m')
+            download_file(_SFD_URL_NGP,
+                          os.path.join(os.getenv('DUST_DIR'),'maps',
+                                       'SFD_dust_4096_ngp.fits'),
+                          'SFD')
+            chown_file(os.path.join(os.getenv('DUST_DIR'),
+                       'maps','SFD_dust_4096_ngp.fits'))
+
         if not os.path.exists(os.path.join(os.getenv('DUST_DIR'),'maps',
                                            'SFD_dust_4096_sgp.fits')):
-            try:
-                subprocess.check_call(['curl','-sfL',_SFD_URL_SGP,'-o',
-                                       os.path.join(os.getenv('DUST_DIR'),'maps',
-                                                    'SFD_dust_4096_sgp.fits')])
-            except subprocess.CalledProcessError:
-                print('\033[1m'+"Downloading SFD dust-map data from %s failed ..." % _SFD_URL_SGP +'\033[0m')
-            try:
-                subprocess.check_call(['chown',os.getenv('SUDO_USER'),
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'maps',
-                                                    'SFD_dust_4096_sgp.fits')])
-            except (subprocess.CalledProcessError,TypeError):
-                print('\033[1m'+"Problem changing ownership of data file..."+'\033[0m')
+            download_file(_SFD_URL_SGP,
+                          os.path.join(os.getenv('DUST_DIR'),'maps',
+                                       'SFD_dust_4096_sgp.fits'),
+                          'SFD')
+            chown_file(os.path.join(os.getenv('DUST_DIR'),
+                       'maps','SFD_dust_4096_sgp.fits'))
 
 #Download Drimmel data
 _DRIMMEL_URL= 'ftp://ftp.oato.inaf.it/astrometria/extinction/data-for.tar.gz'
 if _DOWNLOAD_DRIMMEL \
         and sys.argv[1] in ('build','install','develop','bdist','bdist_egg'):
     if not os.path.exists('mwdust/util/drimmeldata/data-for.tar.gz'):
-        print('\033[1m'+'Downloading Drimmel et al. (2003) dust maps ...'+'\033[0m')
-        try:
-            subprocess.check_call(['curl','-sfL','%s' % _DRIMMEL_URL,
-                                   '-o','mwdust/util/drimmeldata/data-for.tar.gz'])
-        except subprocess.CalledProcessError:
-            print("Downloading Drimmel dust-map data from %s failed ..." % _DRIMMEL_URL)
-        try:
-            subprocess.check_call(['tar','xvzf',
-                                   'mwdust/util/drimmeldata/data-for.tar.gz',
-                                   '-C','mwdust/util/drimmeldata/'])
-        except subprocess.CalledProcessError:
-            print("Untarring Drimmel dust-map data failed ...")
+        download_file(_DRIMMEL_URL,
+                      'mwdust/util/drimmeldata/data-for.tar.gz',
+                      'Drimmel et al. (2003)')
+        if not _TEST_DOWNLOADS:
+            try:
+                subprocess.check_call(['tar','xvzf',
+                                    'mwdust/util/drimmeldata/data-for.tar.gz',
+                                    '-C','mwdust/util/drimmeldata/'])
+            except subprocess.CalledProcessError:
+                print("Untarring Drimmel dust-map data failed ...")
 
 #Download Marshall data
 _MARSHALL_URL= 'ftp://cdsarc.u-strasbg.fr/pub/cats/J/A%2BA/453/635'
@@ -139,47 +166,28 @@ if _DOWNLOAD_MARSHALL and sys.argv[1] in ('install','develop'):
                 print('\033[1m'+"Problem changing ownership of data directory ..."+'\033[0m')
         if not os.path.exists(os.path.join(os.getenv('DUST_DIR'),'marshall06',
                                                 'table1.dat')):
-            print('\033[1m'+'Downloading Marshall et al. (2006) dust maps ...'+'\033[0m')
-            try:
-                subprocess.check_call(['curl','-sfL',
-                                       '%s/table1.dat.gz' % _MARSHALL_URL,
-                                       '-o',
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'marshall06',
-                                                    'table1.dat.gz')])
-            except subprocess.CalledProcessError:
-                print('\033[1m'+"Downloading Marshall dust-map data from %s/table1.dat.gz failed ..." % _MARSHALL_URL +'\033[0m')
-            try:
-                subprocess.check_call(['gzip','-d',
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'marshall06',
-                                                    'table1.dat.gz')],
-                                      shell=WIN32)
-            except (subprocess.CalledProcessError,FileNotFoundError):
-                print('\033[1m'+"Gunzipping Marshall et al. dust-map data failed ..."+'\033[0m')
-            try:
-                subprocess.check_call(['chown',os.getenv('SUDO_USER'),
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'marshall06',
-                                                    'table1.dat')])
-            except (subprocess.CalledProcessError,TypeError):
-                print('\033[1m'+"Problem changing ownership of data file..."+'\033[0m')
+            download_file('{}/table1.dat.gz'.format(_MARSHALL_URL),
+                          os.path.join(os.getenv('DUST_DIR'),
+                                       'marshall06','table1.dat.gz'),
+                          'Marshall et al. (2006)')     
+            if not _TEST_DOWNLOADS:
+                try:
+                    subprocess.check_call(['gzip','-d',
+                                        os.path.join(os.getenv('DUST_DIR'),
+                                                        'marshall06',
+                                                        'table1.dat.gz')],
+                                        shell=WIN32)
+                except (subprocess.CalledProcessError,FileNotFoundError):
+                    print('\033[1m'+"Gunzipping Marshall et al. dust-map data failed ..."+'\033[0m')
+            chown_file(os.path.join(os.getenv('DUST_DIR'),'marshall06',
+                       'table1.dat'))
             #Also download the ReadMe file
-            try:
-                subprocess.check_call(['curl','-sfL','%s/ReadMe' % _MARSHALL_URL,
-                                       '-o',
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'marshall06',
-                                                    'ReadMe')])
-            except subprocess.CalledProcessError:
-                print('\033[1m'+"Downloading Marshall dust-map ReadMe from %s/ReadMe failed ..." % _MARSHALL_URL+'\033[0m')
-            try:
-                subprocess.check_call(['chown',os.getenv('SUDO_USER'),
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'marshall06',
-                                                    'ReadMe')])
-            except (subprocess.CalledProcessError,TypeError):
-                print('\033[1m'+"Problem changing ownership of data file..."+'\033[0m')
+            download_file('{}/ReadMe'.format(_MARSHALL_URL),
+                          os.path.join(os.getenv('DUST_DIR'),
+                                       'marshall06','ReadMe'),
+                          'Marshall et al. (2006)')
+            chown_file(os.path.join(os.getenv('DUST_DIR'),'marshall06',
+                                    'ReadMe'))
 
 #Download Sale data, currently unavailable from CDS
 _SALE_CDS= False
@@ -204,89 +212,70 @@ if _DOWNLOAD_SALE and sys.argv[1] in ('install','develop'):
                                                 'table1.dat')) 
                 or os.path.exists(os.path.join(os.getenv('DUST_DIR'),'sale14',
                                                 'Amap.dat'))):
-            print('\033[1m'+'Downloading Sale et al. (2014) dust maps ...'+'\033[0m')
             if _SALE_CDS:
-                try:
-                    subprocess.check_call(['curl','-sfL',
-                                           '%s/table1.dat.gz' % _SALE_URL,
-                                           '-o',
-                                           os.path.join(os.getenv('DUST_DIR'),
-                                                        'sale14',
-                                                        'table1.dat.gz')])
-                except subprocess.CalledProcessError:
-                    print('\033[1m'+"Downloading Sale dust-map data from %s/table1.dat.gz failed ..." % _SALE_URL +'\033[0m')
-                try:
-                    subprocess.check_call(['gunzip',
-                                           os.path.join(os.getenv('DUST_DIR'),
-                                                        'sale14',
-                                                        'table1.dat.gz')])
-                except subprocess.CalledProcessError:
-                    print('\033[1m'+"Gunzipping Sale et al. dust-map data failed ..."+'\033[0m')
-                try:
-                    subprocess.check_call(['chown',os.getenv('SUDO_USER'),
-                                           os.path.join(os.getenv('DUST_DIR'),
-                                                        'sale14',
-                                                        'table1.dat')])
-                except (subprocess.CalledProcessError,TypeError):
-                    print('\033[1m'+"Problem changing ownership of data file..."+'\033[0m')
+                download_file('{}/table1.dat.gz'.format(_SALE_URL),
+                              os.path.join(os.getenv('DUST_DIR'),
+                                           'sale14',
+                                           'table1.dat.gz'),
+                              'Sale')
+                if not _TEST_DOWNLOADS:
+                    try:
+                        subprocess.check_call(['gzip','-d',
+                                               os.path.join(os.getenv('DUST_DIR'),
+                                                            'sale14',
+                                                            'table1.dat.gz')])
+                    except subprocess.CalledProcessError:
+                        print('\033[1m'+"Gunzipping Sale et al. dust-map data failed ..."+'\033[0m')
+                    chown_file(os.path.join(os.getenv('DUST_DIR'),'sale14',
+                                            'table1.dat'))
                 #Also download the ReadMe file
-                try:
-                    subprocess.check_call(['curl','-sfL','%s/ReadMe' % _SALE_URL,
-                                           '-o',
-                                           os.path.join(os.getenv('DUST_DIR'),
-                                                        'sale14',
-                                                        'ReadMe')])
-                except subprocess.CalledProcessError:
-                    print('\033[1m'+"Downloading Sale dust-map ReadMe from %s/ReadMe failed ..." % _SALE_URL+'\033[0m')
-                try:
-                    subprocess.check_call(['chown',os.getenv('SUDO_USER'),
-                                           os.path.join(os.getenv('DUST_DIR'),
-                                                        'sale14',
-                                                        'ReadMe')])
-                except (subprocess.CalledProcessError,TypeError):
-                    print('\033[1m'+"Problem changing ownership of data file..."+'\033[0m')
+                download_file('{}/ReadMe'.format(_SALE_URL),
+                              os.path.join(os.getenv('DUST_DIR'),
+                                           'sale14',
+                                           'ReadMe'),
+                              'Sale')
+                chown_file(os.path.join(os.getenv('DUST_DIR'),'sale14',
+                                        'ReadMe'))
             else:
-                try:
-                    subprocess.check_call(['curl','-sfL',
-                                           _SALE_URL,
-                                           '-o',
-                                           os.path.join(os.getenv('DUST_DIR'),
-                                                        'sale14',
-                                                        'Amap.tar.gz')])
-                except subprocess.CalledProcessError:
-                    print('\033[1m'+"Downloading Sale dust-map data from %s failed ..." % _SALE_URL +'\033[0m')
-                try:
-                    subprocess.check_call(['tar','xvzf',
-                                           os.path.join(os.getenv('DUST_DIR'),
+                download_file(_SALE_URL,
+                              os.path.join(os.getenv('DUST_DIR'),
                                                         'sale14',
                                                         'Amap.tar.gz'),
-                                           '-C',
-                                           os.path.join(os.getenv('DUST_DIR'),
-                                                        'sale14')])
-                except subprocess.CalledProcessError:
-                    print('\033[1m'+"Untarring/unzipping Sale et al. dust-map data failed ..."+'\033[0m')
-                try:
-                    os.remove(os.path.join(os.getenv('DUST_DIR'),'sale14',
-                                           'Amap.tar.gz'))
-                except subprocess.CalledProcessError:
-                    print('\033[1m'+"Removing Sale et al. dust-map tarred data failed ..."+'\033[0m')
+                              'Sale')
+                if not _TEST_DOWNLOADS:
+                    try:
+                        subprocess.check_call(['tar','xvzf',
+                                            os.path.join(os.getenv('DUST_DIR'),
+                                                            'sale14',
+                                                            'Amap.tar.gz'),
+                                            '-C',
+                                            os.path.join(os.getenv('DUST_DIR'),
+                                                            'sale14')])
+                    except subprocess.CalledProcessError:
+                        print('\033[1m'+"Untarring/unzipping Sale et al. dust-map data failed ..."+'\033[0m')
+                    try:
+                        os.remove(os.path.join(os.getenv('DUST_DIR'),'sale14',
+                                            'Amap.tar.gz'))
+                    except subprocess.CalledProcessError:
+                        print('\033[1m'+"Removing Sale et al. dust-map tarred data failed ..."+'\033[0m')
             # Fix one line in the dust map
-            with open("tmp.dat", "w") as fout:
-                with open(os.path.join(os.getenv('DUST_DIR'),'sale14',
-                                           'Amap.dat'),'r') as fin:
-                    for line in fin:
-                        if '15960.40000' in line: # bad line
-                            newline= ''
-                            for ii,word in enumerate(line.split(' ')):
-                                if ii > 0: newline+= ' '
-                                if ii > 6 and len(word) > 9:
-                                    word= '747.91400'
-                                newline+= word
-                            fout.write(newline+'\n')
-                        else:
-                            fout.write(line)
-            shutil.move('tmp.dat',os.path.join(os.getenv('DUST_DIR'),'sale14',
-                                               'Amap.dat'))
+            if not _TEST_DOWNLOADS:
+                with open("tmp.dat", "w") as fout:
+                    with open(os.path.join(os.getenv('DUST_DIR'),'sale14',
+                                            'Amap.dat'),'r') as fin:
+                        for line in fin:
+                            if '15960.40000' in line: # bad line
+                                newline= ''
+                                for ii,word in enumerate(line.split(' ')):
+                                    if ii > 0: newline+= ' '
+                                    if ii > 6 and len(word) > 9:
+                                        word= '747.91400'
+                                    newline+= word
+                                fout.write(newline+'\n')
+                            else:
+                                fout.write(line)
+                shutil.move('tmp.dat',os.path.join(os.getenv('DUST_DIR'),'sale14',
+                                                'Amap.dat'))
 
 #Download Green et al. PanSTARRS data (alt.: http://dx.doi.org/10.7910/DVN/40C44C)
 _GREEN_URL= 'http://faun.rc.fas.harvard.edu/pan1/ggreen/argonaut/data/dust-map-3d.h5'
@@ -305,23 +294,13 @@ if _DOWNLOAD_GREEN and sys.argv[1] in ('install','develop'):
                 print('\033[1m'+"Problem changing ownership of data directory ..."+'\033[0m')
         if not os.path.exists(os.path.join(os.getenv('DUST_DIR'),'green15',
                                            'dust-map-3d.h5')):
-            print('\033[1m'+'Downloading Green et al. (2015) dust maps ...'+'\033[0m')
-            try:
-                subprocess.check_call(['curl','-sfL',
-                                       _GREEN_URL,
-                                       '-o',
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'green15',
-                                                    'dust-map-3d.h5')])
-            except subprocess.CalledProcessError:
-                print('\033[1m'+"Downloading Green dust-map data from %s failed ..." % _GREEN_URL +'\033[0m')
-            try:
-                subprocess.check_call(['chown',os.getenv('SUDO_USER'),
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'green15',
-                                                    'dust-map-3d.h5')])
-            except (subprocess.CalledProcessError,TypeError):
-                print('\033[1m'+"Problem changing ownership of data file..."+'\033[0m')
+            download_file(_GREEN_URL,
+                          os.path.join(os.getenv('DUST_DIR'),
+                                       'green15',
+                                       'dust-map-3d.h5'),
+                          'Green et al. (2015)')
+            chown_file(os.path.join(os.getenv('DUST_DIR'),'green15',
+                                    'dust-map-3d.h5'))
 
 #Download Green et al. 2018 PanSTARRS data
 _GREEN_URL= 'https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/LCYHJG/S7MP4P'
@@ -340,23 +319,14 @@ if _DOWNLOAD_GREEN17 and sys.argv[1] in ('install','develop'):
                 print('\033[1m'+"Problem changing ownership of data directory ..."+'\033[0m')
         if not os.path.exists(os.path.join(os.getenv('DUST_DIR'),'green17',
                                            'bayestar2017.h5')):
-            print('\033[1m'+'Downloading Green et al. (2018) dust maps ...'+'\033[0m')
-            try:
-                subprocess.check_call(['curl','-sfL',
-                                       _GREEN_URL,
-                                       '-o',
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'green17',
-                                                    'bayestar2017.h5')])
-            except subprocess.CalledProcessError:
-                print('\033[1m'+"Downloading Green 2018 dust-map data from %s failed ..." % _GREEN_URL +'\033[0m')
-            try:
-                subprocess.check_call(['chown',os.getenv('SUDO_USER'),
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'green17',
-                                                    'bayestar2017.h5')])
-            except (subprocess.CalledProcessError,TypeError):
-                print('\033[1m'+"Problem changing ownership of data file..."+'\033[0m')
+            download_file(_GREEN_URL,
+                          os.path.join(os.getenv('DUST_DIR'),
+                                       'green17',
+                                       'bayestar2017.h5'),
+                          'Green et al. (2018)',
+                          notest=True)
+            chown_file(os.path.join(os.getenv('DUST_DIR'),'green17',
+                                    'bayestar2017.h5'))
 
 #Download Green et al. 2019 PanSTARRS data
 _GREEN_URL= 'https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/2EJ9TX/1CUGA1'
@@ -375,24 +345,14 @@ if _DOWNLOAD_GREEN19 and sys.argv[1] in ('install','develop'):
                 print('\033[1m'+"Problem changing ownership of data directory ..."+'\033[0m')
         if not os.path.exists(os.path.join(os.getenv('DUST_DIR'),'green19',
                                            'bayestar2019.h5')):
-            print('\033[1m'+'Downloading Green et al. (2019) dust maps ...'+'\033[0m')
-            try:
-                subprocess.check_call(['curl','-sfL',
-                                       _GREEN_URL,
-                                       '-o',
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'green19',
-                                                    'bayestar2019.h5')])
-            except subprocess.CalledProcessError:
-                print('\033[1m'+"Downloading Green 2019 dust-map data from %s failed ..." % _GREEN_URL +'\033[0m')
-            try:
-                subprocess.check_call(['chown',os.getenv('SUDO_USER'),
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'green19',
-                                                    'bayestar2019.h5')])
-            except (subprocess.CalledProcessError,TypeError):
-                print('\033[1m'+"Problem changing ownership of data file..."+'\033[0m')
-
+            download_file(_GREEN_URL,
+                          os.path.join(os.getenv('DUST_DIR'),
+                                       'green19',
+                                       'bayestar2019.h5'),
+                          'Green et al. (2019)',
+                          notest=True)
+            chown_file(os.path.join(os.getenv('DUST_DIR'),'green19',
+                       'bayestar2019.h5'))
 
 #Download the combined map: Marshall+Green19+Drimmel for full sky coverage
 _COMBINED_URL= 'https://zenodo.org/record/3566060/files/combine19.h5'
@@ -411,25 +371,13 @@ if _DOWNLOAD_COMBINED19 and sys.argv[1] in ('install','develop'):
                 print('\033[1m'+"Problem changing ownership of data directory ..."+'\033[0m')
         if not os.path.exists(os.path.join(os.getenv('DUST_DIR'),'combined19',
                                            'combine19.h5')):
-            print('\033[1m'+'Downloading combined dust map (2019) ...'+'\033[0m')
-            try:
-                subprocess.check_call(['curl','-sfL',
-                                       _COMBINED_URL,
-                                       '-o',
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'combined19',
-                                                    'combine19.h5')])
-            except subprocess.CalledProcessError:
-                print('\033[1m'+"Downloading combined dust-map data from %s failed ..." % _COMBINED_URL +'\033[0m')
-            try:
-                subprocess.check_call(['chown',os.getenv('SUDO_USER'),
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'combined19',
-                                                    'combine19.h5')])
-            except (subprocess.CalledProcessError,TypeError):
-                print('\033[1m'+"Problem changing ownership of data file..."+'\033[0m')
-
-
+            download_file(_COMBINED_URL,
+                          os.path.join(os.getenv('DUST_DIR'),
+                                       'combined19',
+                                       'combine19.h5'),
+                          'combined 2019')
+            chown_file(os.path.join(os.getenv('DUST_DIR'),'combined19',
+                                    'combine19.h5'))
 
 #Download the combined map of Bovy et al. (2015): Marshall+Green+Drimmel for full sky coverage
 _COMBINED_URL= 'https://zenodo.org/record/31262/files/dust-map-3d.h5'
@@ -448,23 +396,17 @@ if _DOWNLOAD_COMBINED and sys.argv[1] in ('install','develop'):
                 print('\033[1m'+"Problem changing ownership of data directory ..."+'\033[0m')
         if not os.path.exists(os.path.join(os.getenv('DUST_DIR'),'combined15',
                                            'dust-map-3d.h5')):
-            print('\033[1m'+'Downloading combined dust map (2015) ...'+'\033[0m')
-            try:
-                subprocess.check_call(['curl','-sfL',
-                                       _COMBINED_URL,
-                                       '-o',
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'combined15',
-                                                    'dust-map-3d.h5')])
-            except subprocess.CalledProcessError:
-                print('\033[1m'+"Downloading combined dust-map data from %s failed ..." % _COMBINED_URL +'\033[0m')
-            try:
-                subprocess.check_call(['chown',os.getenv('SUDO_USER'),
-                                       os.path.join(os.getenv('DUST_DIR'),
-                                                    'combined15',
-                                                    'dust-map-3d.h5')])
-            except (subprocess.CalledProcessError,TypeError):
-                print('\033[1m'+"Problem changing ownership of data file..."+'\033[0m')
+            download_file(_COMBINED_URL,
+                          os.path.join(os.getenv('DUST_DIR'),
+                                       'combined15',
+                                       'dust-map-3d.h5'),
+                          'combined 2015')
+            chown_file(os.path.join(os.getenv('DUST_DIR'),
+                                    'combined15',
+                                    'dust-map-3d.h5'))
+
+if _TEST_DOWNLOADS:
+    sys.exit()
 
 #SFD  extension
 sfd_c_src= glob.glob('mwdust/util/SFD_CodeC/*.c')


### PR DESCRIPTION
This PR attempts to allow the code to be used a bit more on Windows, by switching the downloads to `cURL` and making the code installable on Windows. However, there are still severe limitations:

- The SFD map is unavailable, because its C code is not compiled on Windows
- Maps based on a hierarchical HEALPIx representation are unavailable because of the lack of `healpy` builds for Windows. This affects all `CombinedXX` and `GreenXX` maps

Thus, the code still isn't that useful on Windows, but it's better than it was! 

Also added a more extensive test suite that tests the downloads and runs on all three major OSs.