### PR TITLE
remove asciitable and bovy_plot dependencies

### DIFF
--- a/mwdust/DustMap3D.py
+++ b/mwdust/DustMap3D.py
@@ -6,7 +6,7 @@
 ###############################################################################
 import numpy
 try:
-    from galpy.util import bovy_plot
+    from galpy.util import plot as bovy_plot
     _BOVY_PLOT_LOADED= True
 except ImportError:
     _BOVY_PLOT_LOADED= False
@@ -61,7 +61,7 @@ class DustMap3D:
            l,b - Galactic longitude and latitude (degree)
            range= distance range in kpc
            distmod= (False) if True, plot as a function of distance modulus (range is distmod range)
-           bovy_plot.bovy_plot args and kwargs
+           bovy_plot.plot args and kwargs
         OUTPUT:
            plot to output device
         HISTORY:
@@ -91,4 +91,4 @@ class DustMap3D:
             kwargs['ylabel']= r'$A_{%s}\,(\mathrm{mag})$' % (self._filter.split(' ')[-1])
         else:
             kwargs['ylabel']= r'$E(B-V)\,(\mathrm{mag})$'
-        return bovy_plot.bovy_plot(ds,adust,*args,**kwargs)
+        return bovy_plot.plot(ds,adust,*args,**kwargs)

--- a/mwdust/Marshall06.py
+++ b/mwdust/Marshall06.py
@@ -7,12 +7,12 @@ import os, os.path
 import sys
 import numpy
 from scipy import interpolate
-import asciitable
+from astropy.io import ascii
 from mwdust.util.extCurves import aebv
 from mwdust.util.tools import cos_sphere_dist
 from mwdust.DustMap3D import DustMap3D
 try:
-    from galpy.util import bovy_plot
+    from galpy.util import plot as bovy_plot
     _BOVY_PLOT_LOADED= True
 except ImportError:
     _BOVY_PLOT_LOADED= False
@@ -41,12 +41,11 @@ class Marshall06(DustMap3D):
         #Read the maps
         sys.stdout.write('\r'+"Reading Marshall et al. (2006) data file ...\r")
         sys.stdout.flush()
-        self._marshalldata= asciitable.read(os.path.join(_marshalldir,
+        self._marshalldata= ascii.read(os.path.join(_marshalldir,
                                                          'table1.dat'),
                                             readme=os.path.join(_marshalldir,
                                                                 'ReadMe'),
-                                            Reader=asciitable.cds.Cds,
-                                            guess=False,
+                                            guess=False, format='cds',
                                             fill_values=[('', '-999')])
         sys.stdout.write('\r'+_ERASESTR+'\r')
         sys.stdout.flush()
@@ -208,7 +207,7 @@ class Marshall06(DustMap3D):
            distance
         INPUT:
            l,b - Galactic longitude and latitude (degree)
-           bovy_plot.bovy_plot args and kwargs
+           bovy_plot.plot args and kwargs
         OUTPUT:
            plot to output device
         HISTORY:
@@ -225,7 +224,7 @@ class Marshall06(DustMap3D):
             filterFac= 1./aebv('2MASS Ks',sf10=self._sf10)\
                 *aebv(self._filter,sf10=self._sf10)
         #Plot
-        out= bovy_plot.bovy_plot(tdata['dist'],tdata['aks']*filterFac,
+        out= bovy_plot.plot(tdata['dist'],tdata['aks']*filterFac,
                             *args,**kwargs)
         #uncertainties
         pyplot.errorbar(tdata['dist'],tdata['aks']*filterFac,

--- a/mwdust/Sale14.py
+++ b/mwdust/Sale14.py
@@ -7,7 +7,7 @@ import os, os.path
 import sys
 import numpy
 from scipy import interpolate
-import asciitable
+from astropy.io import ascii
 from mwdust.util.extCurves import aebv
 from mwdust.util.tools import cos_sphere_dist
 from mwdust.DustMap3D import DustMap3D
@@ -35,12 +35,11 @@ class Sale14(DustMap3D):
         #Read the maps
         sys.stdout.write('\r'+"Reading Sale et al. (2014) data file ...\r")
         sys.stdout.flush()
-        self._saledata= asciitable.read(os.path.join(_saledir,
+        self._saledata= ascii.read(os.path.join(_saledir,
                                                      'Amap.dat'),
                                         readme=os.path.join(_saledir,
                                                             'ReadMe'),
-                                        Reader=asciitable.cds.Cds,
-                                        guess=False,
+                                        guess=False, format='cds',
                                         fill_values=[('', '-999')])
         sys.stdout.write('\r'+_ERASESTR+'\r')
         sys.stdout.flush()

--- a/setup.py
+++ b/setup.py
@@ -423,8 +423,7 @@ if not WIN32:
 else:
     ext_modules= None
 
-install_requires= ['numpy','scipy','matplotlib','asciitable',
-                   'h5py']
+install_requires= ['numpy','scipy','matplotlib', 'h5py']
 if not WIN32:
     install_requires.append('healpy')
 


### PR DESCRIPTION
`asciitable` can not be used with `numpy >=1.24` because `numpy` has removed `np.int`. Since `asciitable`  was discontinued, we can use astropy to do the same functionality. 