### PR TITLE
vectorize ``HierarchicalHealpixMap`` evluate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ roughly the following lay-out::
           bayestar2019.h5
        maps/
           SFD_dust_4096_ngp.fits
-	       SFD_dust_4096_sgp.fits
+          SFD_dust_4096_sgp.fits
        marshall06/
           ReadMe
 	       table1.dat

--- a/README.rst
+++ b/README.rst
@@ -127,10 +127,15 @@ and they can be plotted as a function of distance at a given (l,b)
 
    combined.plot(55.,0.5) # inputs are (l,b)
 
-(plot not shown). Maps that are derived from the
-``HierarchicalHealpixMap.py`` class (currently all Green-type maps and
-the combined maps) can also be plotted on the sky using a Mollweide
-projection at a given distance using
+(plot not shown). Maps that are derived from the ``HierarchicalHealpixMap.py`` class (currently all Green-type maps and
+the combined maps) can be vectorized to evaluate on array inputs of *l*, *b*, *D*
+
+..  code-block:: python
+
+   combined(numpy.array([30.,40.,50.,60.]),numpy.array([3.,4.,3.,6.]),numpy.array([1.,2.,3.,10.]))
+   array([0.22304147, 0.3780736 , 0.42528571, 0.22258065])
+
+They can also be plotted on the sky using a Mollweide projection at a given distance using
 
 ..  code-block:: python
 

--- a/mwdust/util/healpix.py
+++ b/mwdust/util/healpix.py
@@ -38,7 +38,7 @@ def check_nside(nside, nest=False):
     # nside can only be a power of 2 for nest, but generally less than 2**29
     nside_arr = np.array(nside).astype(np.int64)
     is_ok = True
-    if nside == nside_arr and 0 < nside and nside <= 2**29:
+    if np.all(np.logical_and(np.logical_and(nside == nside_arr, np.all(np.less(0, nside))), nside_arr <= 2**29)):
         if nest:
             is_ok = (nside_arr & (nside_arr - 1)) == 0
     else:

--- a/tests/test_green19.py
+++ b/tests/test_green19.py
@@ -4,7 +4,7 @@ from numpy.random import default_rng
 rng= default_rng()
 
 
-def test_distance_dependent():
+def test_distance_dependent_forloop():
     # Test that extinction from the Green19 map monotonicaly increases 
     # with distance for a given line of sight.
     from mwdust import Green19
@@ -16,12 +16,27 @@ def test_distance_dependent():
                             for ii in range(len(glons))]
                             for jj in range(len(dists))]).T     
     assert numpy.all(numpy.fabs(ebvs-ebvs[0])>=0), \
-        'Green19 extinction does not monotonically increase with distance for at lease one given line of sight'
+        'For-loop Green19 extinction does not monotonically increase with distance for at lease one given line of sight'
     return None
 
 
-def test_against_known_values():
-    # Test that the SFD extinction agrees with a table of known values
+def test_distance_dependent_vectorized():
+    # Test that extinction from the Green19 map monotonicaly increases 
+    # with distance for a given line of sight.
+    from mwdust import Green19
+    green19= Green19()
+    glons= rng.uniform(50.,220.,size=20)
+    glats= rng.uniform(-90.,90.,size=20)
+    dists= rng.uniform(0.01,1.,size=5)
+    ebvs= numpy.array([[green19(glons[ii],glats[ii],dists) \
+                            for ii in range(len(glons))]]).T 
+    assert numpy.all(numpy.fabs(ebvs-ebvs[0])>=0), \
+        'Vectorized Green19 extinction does not monotonically increase with distance for at lease one given line of sight'
+    return None
+
+
+def test_against_known_values_forloop():
+    # Test that the Green19 extinction agrees with a table of known values
     # These were computed using mwdust on Linux using mwdust 1.2
     # before custom healpix functions were implemented (thus computed using healpy)
     from mwdust import Green19
@@ -33,5 +48,22 @@ def test_against_known_values():
     ebvs= known.T[3]
     assert numpy.all(ebvs-[green19(glon,glat,dist)[0]
                             for glon,glat,dist in zip(glons,glats,dists)] < 10.**-8.), \
-        'Green19 extinction does not agree with known values'
+        'For-loop Green19 extinction does not agree with known values'
+    return None
+
+
+def test_against_known_values_vectorized():
+    # Test that the Green19 extinction agrees with a table of known values
+    # These were computed using mwdust on Linux using mwdust 1.2
+    # before custom healpix functions were implemented (thus computed using healpy)
+    # and before the vectorized version of the Green19 map was implemented
+    from mwdust import Green19
+    green19= Green19()
+    known= numpy.loadtxt(pathlib.Path(__file__).parent / 'green19_benchmark.dat',delimiter=',')
+    glons= known.T[0]
+    glats= known.T[1]
+    dists= known.T[2]
+    ebvs= known.T[3]
+    assert numpy.all(ebvs-green19(glons,glats,dists) < 10.**-8.), \
+        'Vectorized Green19 extinction does not agree with known values'
     return None


### PR DESCRIPTION
This PR adds a vectorized version to evaluate  ``HierarchicalHealpixMap``.

I have tested the performance of evaluating ``Combined19`` on the whole APOGEE DR17. Simple for loop took 6h56m41s while this PR vectorized function only took 26s. So we can have a speedup of ~1000 times!!

To maintain compatibility, evaluating a single `l` and `b` will fall back to the original code while evaluating array input of `l` and `b` will use the vectorized code.

I have check the consistency of the result on the whole APOGEE DR17 by ``np.all(np.isclose(ebv_original, ebv_vectorized, equal_nan=True))`` and the code to generate the comparison result is as follow

```python
import numpy as np
from mwdust import Combined19
from astropy.io import fits
from astroNN.apogee import allstar
from galpy.util.coords import radec_to_lb

allstar_f = fits.getdata(allstar(dr=17))

lb = radec_to_lb(allstar_f['RA'], allstar_f['DEC'], degree=True)
ls, bs = lb[:, 0], lb[:, 1]

c19map = Combined19()
ebv = np.zeros_like(ls) * np.nan
for idx, (l, b, d) in enumerate(zip(ls, bs, 1 / allstar_f['GAIAEDR3_PARALLAX'])):
    try:
        ebv[idx] = c19map(l, b, d)
    except:
        pass
np.save("ebv_original.npy", ebv)
```
[ebv_original.zip](https://github.com/jobovy/mwdust/files/11958427/ebv_original.zip)

```python
import numpy as np
from mwdust import Combined19
from astropy.io import fits
from astroNN.apogee import allstar
from galpy.util.coords import radec_to_lb

allstar_f = fits.getdata(allstar(dr=17))

lb = radec_to_lb(allstar_f['RA'], allstar_f['DEC'], degree=True)
ls, bs = lb[:, 0], lb[:, 1]

c19map = Combined19()
# you don't need to call _evaluate_vectorize directly, but here I will do that to clearly show which code is used
ebv = c19map._evaluate_vectorize(ls, bs, 1 / allstar_f['GAIAEDR3_PARALLAX'])
np.save("ebv_vectorized.npy", ebv)
```
[ebv_vectorized.zip](https://github.com/jobovy/mwdust/files/11958445/ebv_vectorized.zip)
