### PR TITLE
Drop Python 3.8 from wheels and bump build workflow numpy versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest,macos-latest,windows-latest]
         python-version: ["3.14"]
-        numpy-version: ["2.3.5","2.4.1"]
+        numpy-version: ["2.4.6","2.5.0"]
     steps:
     - uses: actions/checkout@v6
     - name: Cache dust maps

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,7 +32,7 @@ jobs:
         - [macos-latest, macosx, x86_64]
         - [macos-latest, macosx, arm64]
         - [windows-latest, win, amd64]
-        python: ["cp38", "cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
+        python: ["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
     steps:
       - uses: actions/checkout@v6
       - name: Build wheels


### PR DESCRIPTION
## Summary

- Remove `cp38` from the cibuildwheel Python matrix in `.github/workflows/wheels.yml`, so wheels are no longer built for Python 3.8 (now cp39–cp314).
- Update the numpy versions tested in `.github/workflows/build.yml` to the most recent release (`2.5.0`) and the most recent prior minor series (`2.4.6`), following the existing two-version pattern.

## Details

The build workflow uses `numpy~=${{ matrix.numpy-version }}`, so these pin the latest patch within each minor series. The previous values were `2.3.5` and `2.4.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyDWzLhtamEbiFXtfg4uec)_